### PR TITLE
Bug in String teilString = s1.substring(j, j+i);

### DIFF
--- a/SchroedingerProgrammiertJava/src/de/galileocomputing/schroedinger/java/kapitel04/GemeinsamerSubstring.java
+++ b/SchroedingerProgrammiertJava/src/de/galileocomputing/schroedinger/java/kapitel04/GemeinsamerSubstring.java
@@ -12,7 +12,7 @@ public class GemeinsamerSubstring {
 		String gemeinsamerSubstring = "";
 		for (int i = 0; i < s1.length(); i++) {
 			for(int j = 0; j < s1.length() - i; j++) {
-				String teilString = s1.substring(j, j+i);
+				String teilString = s1.substring(j, j+i+1);
 				if(s2.contains(teilString)) {
 					gemeinsamerSubstring = teilString;
 				}


### PR DESCRIPTION
Hallo,
hier hat sich ein kleiner Bug eingeschlichen, wahrscheinlich wegen der verwirrenden Logik von sibstring(startIndex, endIndex), nämlich dass der Ausschnitt nicht bis zum endIndex geht, sondern bis zum (endIndex - 1):
statt
String teilString = s1.substring(j, j+i);
müsste sein:
String teilString = s1.substring(j, j+i+1); 

Sonst
a) gehen wir am Anfang n-Mal leere Substrings durch
b) das letzte Zeichen von s1 wir nie einbezogen